### PR TITLE
displaying gfx, full image set included

### DIFF
--- a/src/game/images/display_wall_textures.c
+++ b/src/game/images/display_wall_textures.c
@@ -6,121 +6,121 @@
 /*   By: sfarren <sfarren@student.42malaga.com>     +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/04/26 12:05:35 by sfarren           #+#    #+#             */
-/*   Updated: 2025/04/26 15:50:45 by sfarren          ###   ########.fr       */
+/*   Updated: 2025/04/26 15:52:36 by sfarren          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../../../inc/so_long.h"
 
-// static int	top_wall(t_context *context)
-// {
-// 	int		type;
-// 	int		col;
-
-// 	col = 0;
-// 	while (col < context->meta->line_length)
-// 	{
-// 		if (col == 0)
-// 			type = I_TL;
-// 		else if (col == context->meta->line_length - 1)
-// 			type = I_TR;
-// 		else
-// 			type = I_TOP;
-// 		if (display_image(context->game, &context->game->images.walls[type],
-// 				(TILE_SIZE * col), (TILE_SIZE * 0)))
-// 			return (1);
-// 		col++;
-// 	}
-// 	return (0);
-// }
-
-// static int	base_wall(t_context *context)
-// {
-// 	int	type;
-// 	int	col;
-// 	int	row;
-
-// 	row = context->meta->line_length - 1;
-// 	col = 0;
-// 	while (col < context->meta->line_length)
-// 	{
-// 		if (col == 0)
-// 			type = I_BASE_L;
-// 		else if (col == context->meta->line_length - 1)
-// 			type = I_BASE_R;
-// 		else
-// 			type = I_BASE;
-// 		if (display_image(context->game, &context->game->images.walls[type],
-// 				(TILE_SIZE * col), (TILE_SIZE * row)))
-// 			return (1);
-// 		col++;
-// 	}
-// 	return (0);
-// }
-
-// static int	other_walls(t_context *c)
-// {
-// 	int	type;
-// 	int	col;
-// 	int	row;
-
-// 	row = 1;
-// 	while (row < c->meta->line_count - 1)
-// 	{
-// 		col = 0;
-// 		while (col < c->meta->line_length)
-// 		{
-// 			if (col == 0)
-// 				type = I_SIDE_L;
-// 			else if (col == c->meta->line_length - 1)
-// 				type = I_SIDE_R;
-// 			else if (c->game->map[row][col] == K_WALL)
-// 				type = I_MID;
-// 			else
-// 				type = -1;
-// 			if (type != -1 && display_image(c->game,
-// 					&c->game->images.walls[type], (TILE_SIZE * col),
-// 					(TILE_SIZE * row)))
-// 				return (1);
-// 			col++;
-// 		}
-// 		row++;
-// 	}
-// 	return (0);
-// }
-
-// int	display_walls(t_context	*c)
-// {
-// 	int	ret;
-
-// 	ret = top_wall(c);
-// 	ret = base_wall(c);
-// 	ret = other_walls(c);
-// 	if (ret)
-// 		return (1);
-// 	return (0);
-// }
-
-int	display_walls(t_context	*c)
+static int	top_wall(t_context *context)
 {
-	// int	type;
+	int		type;
+	int		col;
+
+	col = 0;
+	while (col < context->meta->line_length)
+	{
+		if (col == 0)
+			type = I_TL;
+		else if (col == context->meta->line_length - 1)
+			type = I_TR;
+		else
+			type = I_TOP;
+		if (display_image(context->game, &context->game->images.walls[type],
+				(TILE_SIZE * col), (TILE_SIZE * 0)))
+			return (1);
+		col++;
+	}
+	return (0);
+}
+
+static int	base_wall(t_context *context)
+{
+	int	type;
 	int	col;
 	int	row;
 
-	row = 0;
-	while (row < c->meta->line_count)
+	row = context->meta->line_length - 1;
+	col = 0;
+	while (col < context->meta->line_length)
+	{
+		if (col == 0)
+			type = I_BASE_L;
+		else if (col == context->meta->line_length - 1)
+			type = I_BASE_R;
+		else
+			type = I_BASE;
+		if (display_image(context->game, &context->game->images.walls[type],
+				(TILE_SIZE * col), (TILE_SIZE * row)))
+			return (1);
+		col++;
+	}
+	return (0);
+}
+
+static int	other_walls(t_context *c)
+{
+	int	type;
+	int	col;
+	int	row;
+
+	row = 1;
+	while (row < c->meta->line_count - 1)
 	{
 		col = 0;
 		while (col < c->meta->line_length)
 		{
-			if (c->game->map[row][col] == K_WALL)
-				if (display_image(c->game,
-						&c->game->images.walls[I_MID], (TILE_SIZE * col),
-						(TILE_SIZE * row)))
-					return (1);
+			if (col == 0)
+				type = I_SIDE_L;
+			else if (col == c->meta->line_length - 1)
+				type = I_SIDE_R;
+			else if (c->game->map[row][col] == K_WALL)
+				type = I_MID;
+			else
+				type = -1;
+			if (type != -1 && display_image(c->game,
+					&c->game->images.walls[type], (TILE_SIZE * col),
+					(TILE_SIZE * row)))
+				return (1);
 			col++;
 		}
 		row++;
 	}
 	return (0);
 }
+
+int	display_walls(t_context	*c)
+{
+	int	ret;
+
+	ret = top_wall(c);
+	ret = base_wall(c);
+	ret = other_walls(c);
+	if (ret)
+		return (1);
+	return (0);
+}
+
+// int	display_walls(t_context	*c)
+// {
+// 	// int	type;
+// 	int	col;
+// 	int	row;
+
+// 	row = 0;
+// 	while (row < c->meta->line_count)
+// 	{
+// 		col = 0;
+// 		while (col < c->meta->line_length)
+// 		{
+// 			if (c->game->map[row][col] == K_WALL)
+// 				if (display_image(c->game,
+// 						&c->game->images.walls[I_MID], (TILE_SIZE * col),
+// 						(TILE_SIZE * row)))
+// 					return (1);
+// 			col++;
+// 		}
+// 		row++;
+// 	}
+// 	return (0);
+// }


### PR DESCRIPTION
This pull request refactors the wall rendering logic in `src/game/images/display_wall_textures.c` to improve code clarity and reusability. The key changes involve reintroducing and updating functions for rendering different types of walls (`top_wall`, `base_wall`, and `other_walls`) and integrating them into a new `display_walls` function.

### Refactoring and Code Reorganization:

* Reintroduced and updated the `top_wall`, `base_wall`, and `other_walls` functions to handle specific wall rendering tasks. These functions now use consistent logic to determine wall types and render them based on the map's layout.
* Added a new `display_walls` function that consolidates calls to the `top_wall`, `base_wall`, and `other_walls` functions, streamlining the rendering process for all wall types. This improves modularity and makes the code easier to maintain.